### PR TITLE
replace line breakers when read rules for peer allowed/disallowed

### DIFF
--- a/src/components/containers/TunnelEditor.tsx
+++ b/src/components/containers/TunnelEditor.tsx
@@ -114,8 +114,8 @@ function TunnelEditor({
     const { name, value } = event.target
     const keys = name.split('.')
 
-    // Remove any quotes from the input value
-    const sanitizedValue = value.replace(/"/g, '')
+    // Remove any quotes and line breakers from the input value
+    const sanitizedValue = value.replace(/"/g, '').replace(/[\n\r]+/g, " ")
 
     if (keys.length === 1) {
       if (keys[0] === 'name') {


### PR DESCRIPTION
In the case of user input using a "line break" after the comma, there is a problem when separating folders/applications. This is easy to overlook from the user's point of view, and it causes the application to ignore the allowed/disallowed rules, effectively stopping performing its main function (I've seen a few issues that most likely happened for this reason) I've had the same problem myself, spending a whole day trying to figure out why tunnel splitting stopped working.

These 2 screenshots clearly demonstrate the problem. In the first case a space is used after the comma and everything is correct, but in the second case a "line break" is used, which leads to the addition of extra characters during reading and further error. It is very difficult for the user to notice his error.
![correct_split](https://github.com/TunnlTo/desktop-app/assets/14150045/5fbbe27c-31d8-4917-b80c-5d65e9ab6c7f)
![incorrect_split](https://github.com/TunnlTo/desktop-app/assets/14150045/c4dc3377-8a01-4a4d-9051-60e9cc851624)

