### PR TITLE
Disable VISIBLE flag with window-state

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -744,7 +744,7 @@ fn main() {
             }
             _ => {}
         })
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(tauri_plugin_window_state::Builder::default().with_state_flags(!StateFlags::VISIBLE).build())
         .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
             println!("{}, {argv:?}, {cwd}", app.package_info().name);
 


### PR DESCRIPTION
Since visibilty on program start is handled in webviews localstorage, prevent window-state plugin from showing window on start.

fixes issue where the window will still pop-up  when `.window-state` file is missing eventhough `minimize on start` is activated.